### PR TITLE
Session validation, Lobby fixing, UI overhaul

### DIFF
--- a/backend_code/Database/database.py
+++ b/backend_code/Database/database.py
@@ -1,4 +1,3 @@
-import os
 import json
 import sqlite3
 from sqlite3 import Error
@@ -57,29 +56,6 @@ def build_game_state_table():
     return conn
 
 
-def insert_game_state_in_db(game_code : str, game_state: dict):
-    sql_insert = """INSERT INTO game_state_table (game_code,game_state,active,timestamp)
-              VALUES(?,?,?,?);"""
-    values = (game_code, json.dumps(game_state), True, get_date_time())
-    with create_connetion(db_file=get_database()) as conn:
-        c = conn.cursor()
-        c.execute(sql_insert, values)
-        conn.commit()
-
-
-def update_game_state_in_db(game_code: str, game_state: dict, activate: bool):
-    sql_update = """UPDATE game_state_table
-              SET game_state = ?,
-              active = ?,
-              timestamp = ? 
-              WHERE game_code = ?"""
-    values = (json.dumps(game_state), activate, get_date_time(), game_code)
-    with create_connetion(db_file=get_database()) as conn:
-        c = conn.cursor()
-        c.execute(sql_update, values)
-        conn.commit()
-
-
 def get_game_state_in_db(game_code: str):
     sql_select = """SELECT game_state FROM game_state_table WHERE game_code=? and active=?"""
     values = (game_code, True)
@@ -90,19 +66,6 @@ def get_game_state_in_db(game_code: str):
         output = c.fetchone()
         conn.commit()
         output = json.loads(output[0])
-    return output
-
-
-def get_game_update_time_in_db(game_code: str):
-    sql_select = """SELECT timestamp FROM game_state_table WHERE game_code=?"""
-    values = (game_code)
-    output = {}
-    with create_connetion(db_file=get_database()) as conn:
-        c = conn.cursor()
-        c.execute(sql_select, values)
-        output = c.fetchone()
-        conn.commit()
-        output = output[0]
     return output
 
 

--- a/backend_code/Game/Systems/DecisionSystem.py
+++ b/backend_code/Game/Systems/DecisionSystem.py
@@ -311,9 +311,19 @@ def validate_multi_card_play(game_state: GameState, player: Player, played_cards
     hand = game_state.players_and_hand.get(player.uuid, [])
     leading_hand = game_state.leading_hand_of_subround
     trump = {'suit': game_state.declare_trump.suit, 'rank': game_state.declare_trump.rank}
+
+    # If this is the leading play, validate the combination
+    if not leading_hand:
+        if len(played_cards) == 1:
+            return True
+        if not is_all_the_same_suit(trump, played_cards):
+            return False
+        play_type = determine_leading_play(trump, played_cards)
+        return play_type != 'invalid'
+
     num_needed = len(leading_hand)
 
-    # Must play the correct number of cards
+    # Following: must play the correct number of cards
     if len(played_cards) != num_needed:
         return False
 
@@ -328,15 +338,6 @@ def validate_multi_card_play(game_state: GameState, player: Player, played_cards
                 break
         if not found:
             return False
-
-    # If this is the leading play, validate the combination
-    if not leading_hand or leading_hand == played_cards:
-        if num_needed == 1:
-            return True
-        if not is_all_the_same_suit(trump, played_cards):
-            return False
-        play_type = determine_leading_play(trump, played_cards)
-        return play_type != 'invalid'
 
     # Following player: must play suit cards first
     leading_card = leading_hand[0]

--- a/backend_code/Game/Systems/GameStateSystem.py
+++ b/backend_code/Game/Systems/GameStateSystem.py
@@ -71,7 +71,9 @@ def is_player_an_alpha(current_game_state: GameState, player_uuid: str) -> bool:
 def set_player_as_leading_player(current_game_state: GameState, player_uuid: str):
     player_idx, check_player = find_player(current_game_state, player_uuid)
     current_game_state.leading_player.player_uuid = check_player.uuid
-    current_game_state.leading_player.index = current_game_state.current_player.index = player_idx
+    current_game_state.leading_player.index = player_idx
+    current_game_state.current_player.player_uuid = check_player.uuid
+    current_game_state.current_player.index = player_idx
 
 
 def set_current_player(current_game_state: GameState, player_uuid: str):

--- a/backend_code/Game/Views/PlayerView.py
+++ b/backend_code/Game/Views/PlayerView.py
@@ -9,6 +9,7 @@ from Game.Views.CardView import card_list_to_emoji_str_list
 from Game.Systems.GameStateSystem import find_player, is_player_an_alpha
 from Game.Systems.TeamSystem import number_of_cards_to_call_friends
 from Game.Modules.EventEnum import GameEventState
+from Game.Modules.CardConstants import Suit, Rank
 
 
 def _serialize_for_json(obj):
@@ -63,6 +64,35 @@ class PlayerView(BaseModel):
         return _serialize_for_json(self.dict())
 
 
+def sort_hand(cards: list, trump_suit, trump_rank) -> list:
+    """Sort a hand of cards: non-trump cards grouped by suit then rank,
+    trump-suit cards next, then trump-rank cards of other suits, then jokers.
+    Within each group, cards are sorted by rank ascending."""
+    SUIT_ORDER = {Suit.CLUB: 0, Suit.SPADE: 1, Suit.HEART: 2, Suit.DIAMOND: 3}
+
+    def card_sort_key(card):
+        is_joker = card.rank == Rank.JOKER
+        is_trump_rank = trump_rank and card.rank == trump_rank and not is_joker
+        is_trump_suit = trump_suit and card.suit == trump_suit and not is_joker
+
+        if is_joker:
+            # Big joker after small joker, both at the very end
+            return (4, 0, card.suit.value)
+        if is_trump_rank and is_trump_suit:
+            # Trump rank in trump suit — highest trump card
+            return (3, 1, 0)
+        if is_trump_rank:
+            # Trump rank in other suits — grouped with trumps
+            return (3, 0, SUIT_ORDER.get(card.suit, 5))
+        if is_trump_suit:
+            # Trump suit (non-trump-rank) — sorted by rank
+            return (2, card.rank.value, 0)
+        # Non-trump: sort by suit then rank
+        return (SUIT_ORDER.get(card.suit, 5), card.rank.value, 0)
+
+    return sorted(cards, key=card_sort_key)
+
+
 def player_view_state(current_game_state: GameState, player_uuid: str) -> PlayerView:
     player_object = current_game_state.player_dict[player_uuid]
     player_view = PlayerView()
@@ -77,7 +107,9 @@ def player_view_state(current_game_state: GameState, player_uuid: str) -> Player
     player_view.players_overall_score = current_game_state.players_overall_score
     player_view.can_start_game = current_game_state.can_start_game
     player_view.player_list = current_game_state.player_order
-    player_view.player_hand = current_game_state.players_and_hand.get(player_uuid, [])
+    raw_hand = current_game_state.players_and_hand.get(player_uuid, [])
+    trump = current_game_state.declare_trump
+    player_view.player_hand = sort_hand(raw_hand, trump.suit, trump.rank)
     player_view.declare_trump = current_game_state.declare_trump
     player_view.cards_in_active_pile = current_game_state.cards_in_active_pile
     player_view.leading_hand_of_subround = current_game_state.leading_hand_of_subround

--- a/backend_code/Main.py
+++ b/backend_code/Main.py
@@ -23,7 +23,7 @@ from Game.Systems.PointSystem import calculate_rounds_points, point_card_pile, c
 from Game.Components.GameState import DeclareCallingCard, DeclareTrump
 from Game.Modules.CardConstants import Suit, Rank
 from Game.Components.Card import Card
-from Database.database import build_game_state_table, upsert_game_state_in_db, get_game_state_in_db, get_game_update_time_in_db
+from Database.database import build_game_state_table, upsert_game_state_in_db, get_game_state_in_db
 
 app = Flask(__name__)
 socketio = SocketIO(app, cors_allowed_origins="*", async_mode='eventlet')
@@ -36,6 +36,21 @@ SITE_URL = "http://127.0.0.1:5050"
 
 # Maps socket session ID -> (game_code, player_uuid)
 SID_TO_PLAYER: Dict[str, Tuple[str, str]] = dict()
+
+def validate_player(game_code: str, player_uuid: str) -> tuple:
+    """Validate that a player belongs to a game. Returns (game_state, error_msg)."""
+    if not game_code:
+        return None, 'missing game_code'
+    if not player_uuid:
+        return None, 'missing player_uuid'
+    try:
+        gs = get_redis_cache(game_code)
+    except Exception:
+        return None, f'Game not found: {game_code}'
+    if player_uuid not in gs.player_dict:
+        return None, f'Player not in this game'
+    return gs, None
+
 
 @app.route("/")
 def hello_world():
@@ -163,7 +178,10 @@ def handle_start_game(data):
         game_code = data.get('game_code', '').lower()
         player_uuid = data.get('player_uuid', '')
 
-        gs = get_redis_cache(game_code)
+        gs, err = validate_player(game_code, player_uuid)
+        if err:
+            emit('error', {'message': err})
+            return
 
         # Validate: game must be in waiting state
         if gs.game_event_state != GameEventState.WAITING_FOR_PLAYERS_TO_JOIN:
@@ -215,7 +233,10 @@ def handle_declare_trump(data):
         suit_str = data.get('suit', '')
         rank_str = data.get('rank', '')
 
-        gs = get_redis_cache(game_code)
+        gs, err = validate_player(game_code, player_uuid)
+        if err:
+            emit('error', {'message': err})
+            return
 
         # Validate: must be in trump declaration phase
         if gs.game_event_state != GameEventState.WAITING_ON_ALPHA_CHOOSE_TRUMP:
@@ -273,7 +294,10 @@ def handle_call_friends(data):
         player_uuid = data.get('player_uuid', '')
         calling_cards_data = data.get('calling_cards', [])
 
-        gs = get_redis_cache(game_code)
+        gs, err = validate_player(game_code, player_uuid)
+        if err:
+            emit('error', {'message': err})
+            return
 
         # Validate: must be in friend calling phase
         if gs.game_event_state != GameEventState.WAITING_ON_ALPHA_FRIEND_CARD_CHOICE:
@@ -338,7 +362,10 @@ def handle_kitty_exchange(data):
         player_uuid = data.get('player_uuid', '')
         discarded_data = data.get('discarded_cards', [])
 
-        gs = get_redis_cache(game_code)
+        gs, err = validate_player(game_code, player_uuid)
+        if err:
+            emit('error', {'message': err})
+            return
 
         # Validate: must be in kitty sort phase
         if gs.game_event_state != GameEventState.WAITING_ON_ALPHA_KITTY_SORT:
@@ -405,7 +432,10 @@ def handle_next_round(data):
         game_code = data.get('game_code', '').lower()
         player_uuid = data.get('player_uuid', '')
 
-        gs = get_redis_cache(game_code)
+        gs, err = validate_player(game_code, player_uuid)
+        if err:
+            emit('error', {'message': err})
+            return
 
         # Validate: must be in round ended state
         if gs.game_event_state != GameEventState.ROUND_ENDED:
@@ -493,7 +523,10 @@ def handle_play_cards(data):
         if not cards_data and 'card' in data:
             cards_data = [data['card']]
 
-        gs = get_redis_cache(game_code)
+        gs, err = validate_player(game_code, player_uuid)
+        if err:
+            emit('error', {'message': err})
+            return
 
         # Validate: must be in round started phase
         if gs.game_event_state != GameEventState.ROUND_STARTED:

--- a/backend_code/Main.py
+++ b/backend_code/Main.py
@@ -37,6 +37,20 @@ SITE_URL = "http://127.0.0.1:5050"
 # Maps socket session ID -> (game_code, player_uuid)
 SID_TO_PLAYER: Dict[str, Tuple[str, str]] = dict()
 
+def parse_suit(value) -> Suit:
+    """Parse a suit from a name string ('SPADE') or integer value (0x20)."""
+    if isinstance(value, str):
+        return Suit[value]
+    return Suit(value)
+
+
+def parse_rank(value) -> Rank:
+    """Parse a rank from a name string ('TWO') or integer value (1)."""
+    if isinstance(value, str):
+        return Rank[value]
+    return Rank(value)
+
+
 def validate_player(game_code: str, player_uuid: str) -> tuple:
     """Validate that a player belongs to a game. Returns (game_state, error_msg)."""
     if not game_code:
@@ -250,8 +264,8 @@ def handle_declare_trump(data):
 
         # Parse suit and rank
         try:
-            declared_suit = Suit(suit_str)
-            declared_rank = Rank(rank_str)
+            declared_suit = parse_suit(suit_str)
+            declared_rank = parse_rank(rank_str)
         except ValueError:
             emit('error', {'message': f'Invalid suit or rank: {suit_str}, {rank_str}'})
             return
@@ -320,8 +334,8 @@ def handle_call_friends(data):
         calling_cards = []
         for cc in calling_cards_data:
             try:
-                suit = Suit(cc['suit'])
-                rank = Rank(cc['rank'])
+                suit = parse_suit(cc['suit'])
+                rank = parse_rank(cc['rank'])
                 order = int(cc['order'])
             except (ValueError, KeyError) as e:
                 emit('error', {'message': f'Invalid calling card: {cc}'})
@@ -386,7 +400,7 @@ def handle_kitty_exchange(data):
         discarded_cards = []
         for dc in discarded_data:
             try:
-                discarded_cards.append(Card(suit=Suit(dc['suit']), rank=Rank(dc['rank'])))
+                discarded_cards.append(Card(suit=parse_suit(dc['suit']), rank=parse_rank(dc['rank'])))
             except (ValueError, KeyError):
                 emit('error', {'message': f'Invalid card: {dc}'})
                 return
@@ -543,7 +557,7 @@ def handle_play_cards(data):
         played_cards = []
         for cd in cards_data:
             try:
-                played_cards.append(Card(suit=Suit(cd['suit']), rank=Rank(cd['rank'])))
+                played_cards.append(Card(suit=parse_suit(cd['suit']), rank=parse_rank(cd['rank'])))
             except (ValueError, KeyError):
                 emit('error', {'message': f'Invalid card: {cd}'})
                 return

--- a/frontend_code/src/App.css
+++ b/frontend_code/src/App.css
@@ -1,38 +1,567 @@
+/* ===== Global App Styles ===== */
+* {
+  box-sizing: border-box;
+}
+
 .App {
-  text-align: center;
-}
-
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-  }
-}
-
-.App-header {
-  background-color: #282c34;
   min-height: 100vh;
+  background: #1a472a;
+  background-image:
+    radial-gradient(ellipse at center, #1e5631 0%, #143520 100%);
+  color: #2c3e50;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+/* ===== Home Screen (Create/Join) ===== */
+.home-screen {
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
+  min-height: 100vh;
+  padding: 20px;
+  gap: 20px;
 }
 
-.App-link {
-  color: #61dafb;
+.home-title {
+  color: #f0e6d3;
+  font-size: 2.2rem;
+  margin-bottom: 10px;
+  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.4);
 }
 
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
+.home-subtitle {
+  color: #b8d4c0;
+  font-size: 1rem;
+  margin-top: -10px;
+  margin-bottom: 20px;
+}
+
+.form-card {
+  background: #f8f5f0;
+  border-radius: 12px;
+  padding: 24px 32px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  width: 100%;
+  max-width: 380px;
+}
+
+.form-card h3 {
+  margin: 0 0 16px 0;
+  color: #2c3e50;
+  font-size: 1.2rem;
+}
+
+.form-card label {
+  display: block;
+  font-size: 0.85rem;
+  color: #666;
+  margin-bottom: 4px;
+  margin-top: 12px;
+}
+
+.form-card input[type="text"] {
+  width: 100%;
+  padding: 10px 12px;
+  border: 2px solid #ddd;
+  border-radius: 8px;
+  font-size: 1rem;
+  transition: border-color 0.2s;
+}
+
+.form-card input[type="text"]:focus {
+  outline: none;
+  border-color: #27ae60;
+}
+
+.btn {
+  display: inline-block;
+  padding: 10px 24px;
+  font-size: 1rem;
+  font-weight: 600;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background-color 0.2s, transform 0.1s;
+}
+
+.btn:active {
+  transform: scale(0.97);
+}
+
+.btn-primary {
+  background-color: #27ae60;
+  color: #fff;
+  margin-top: 16px;
+  width: 100%;
+}
+
+.btn-primary:hover {
+  background-color: #219a52;
+}
+
+.btn-secondary {
+  background-color: #2980b9;
+  color: #fff;
+}
+
+.btn-secondary:hover {
+  background-color: #2472a4;
+}
+
+.btn-orange {
+  background-color: #e67e22;
+  color: #fff;
+}
+
+.btn-orange:hover {
+  background-color: #cf6d17;
+}
+
+.btn-danger {
+  background-color: #e74c3c;
+  color: #fff;
+}
+
+.error-text {
+  color: #e74c3c;
+  font-size: 0.9rem;
+  margin-top: 8px;
+}
+
+/* ===== Lobby ===== */
+.lobby-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 20px;
+}
+
+.lobby-card {
+  background: #f8f5f0;
+  border-radius: 16px;
+  padding: 32px 40px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  width: 100%;
+  max-width: 500px;
+  text-align: center;
+}
+
+.lobby-card h2 {
+  margin: 0 0 4px 0;
+  color: #2c3e50;
+}
+
+.game-code-display {
+  display: inline-block;
+  background: #2c3e50;
+  color: #f0e6d3;
+  padding: 8px 20px;
+  border-radius: 8px;
+  font-size: 1.4rem;
+  font-weight: bold;
+  letter-spacing: 2px;
+  margin: 12px 0;
+  user-select: all;
+}
+
+.player-list {
+  list-style: none;
+  padding: 0;
+  margin: 16px 0;
+}
+
+.player-list li {
+  padding: 8px 16px;
+  margin: 4px 0;
+  background: #eef5f0;
+  border-radius: 8px;
+  font-size: 0.95rem;
+}
+
+.player-list li.is-you {
+  background: #d5f5e3;
+  font-weight: 600;
+}
+
+.lobby-status {
+  color: #7f8c8d;
+  font-style: italic;
+  font-size: 0.9rem;
+  margin-top: 12px;
+}
+
+/* ===== Game Layout ===== */
+.game-container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 12px 16px;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.game-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: rgba(248, 245, 240, 0.95);
+  border-radius: 12px;
+  padding: 12px 20px;
+  margin-bottom: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.game-header-left h2 {
+  margin: 0;
+  font-size: 1.3rem;
+  color: #2c3e50;
+}
+
+.game-header-left .game-code-small {
+  color: #7f8c8d;
+  font-size: 0.8rem;
+}
+
+.game-header-right {
+  text-align: right;
+  font-size: 0.85rem;
+  color: #2c3e50;
+}
+
+.phase-badge {
+  display: inline-block;
+  padding: 4px 12px;
+  border-radius: 12px;
+  font-weight: 600;
+  font-size: 0.8rem;
+  margin-bottom: 4px;
+}
+
+.phase-badge.trump { background: #fdebd0; color: #d35400; }
+.phase-badge.friend { background: #d6eaf8; color: #2471a3; }
+.phase-badge.kitty { background: #fadbd8; color: #c0392b; }
+.phase-badge.playing { background: #d5f5e3; color: #1e8449; }
+.phase-badge.ended { background: #f5f5f5; color: #7f8c8d; }
+
+.trump-info {
+  font-size: 0.85rem;
+}
+
+.alpha-badge {
+  color: #e67e22;
+  font-weight: 600;
+  font-size: 0.8rem;
+}
+
+/* ===== Players Bar ===== */
+.players-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 12px;
+}
+
+.player-chip {
+  padding: 5px 12px;
+  border-radius: 20px;
+  font-size: 0.8rem;
+  background: rgba(248, 245, 240, 0.9);
+  border: 2px solid transparent;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
+}
+
+.player-chip.is-current {
+  border-color: #e67e22;
+  background: #fef5e7;
+}
+
+.player-chip.is-me {
+  background: #d5f5e3;
+}
+
+.player-chip.is-winner {
+  border-color: #27ae60;
+  background: #d5f5e3;
+}
+
+/* ===== Info Panels ===== */
+.info-panel {
+  background: rgba(248, 245, 240, 0.95);
+  border-radius: 10px;
+  padding: 14px 18px;
+  margin-bottom: 10px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.info-panel.waiting {
+  background: rgba(254, 249, 231, 0.95);
+}
+
+.info-panel.action {
+  background: rgba(253, 242, 233, 0.95);
+  border-left: 4px solid #e67e22;
+}
+
+.info-panel.action-blue {
+  background: rgba(234, 242, 248, 0.95);
+  border-left: 4px solid #2980b9;
+}
+
+.info-panel.result {
+  background: rgba(213, 245, 227, 0.95);
+  border-left: 4px solid #27ae60;
+}
+
+.info-panel.error {
+  background: #fdedec;
+  border: 1px solid #e74c3c;
+  color: #c0392b;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.info-panel h3,
+.info-panel h4 {
+  margin: 0 0 8px 0;
+  color: #2c3e50;
+}
+
+.info-panel p {
+  margin: 6px 0;
+  font-size: 0.9rem;
+}
+
+.close-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1.1rem;
+  font-weight: bold;
+  color: inherit;
+  padding: 0 4px;
+}
+
+/* ===== Trick Area ===== */
+.trick-area {
+  background: rgba(30, 86, 49, 0.4);
+  border: 2px dashed rgba(255, 255, 255, 0.2);
+  border-radius: 12px;
+  padding: 16px;
+  margin-bottom: 12px;
+  min-height: 80px;
+}
+
+.trick-area h4 {
+  margin: 0 0 8px 0;
+  color: #f0e6d3;
+  font-size: 0.9rem;
+}
+
+.trick-cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2px;
+}
+
+/* ===== Turn Indicator ===== */
+.turn-indicator {
+  padding: 10px 16px;
+  border-radius: 8px;
+  margin-bottom: 10px;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.turn-indicator.your-turn {
+  background: rgba(39, 174, 96, 0.15);
+  color: #d5f5e3;
+  border: 1px solid rgba(39, 174, 96, 0.3);
+}
+
+.turn-indicator.waiting-turn {
+  background: rgba(255, 255, 255, 0.08);
+  color: #b8d4c0;
+}
+
+/* ===== Called Cards / Revealed Friends ===== */
+.meta-strip {
+  background: rgba(248, 245, 240, 0.85);
+  border-radius: 8px;
+  padding: 8px 14px;
+  margin-bottom: 8px;
+  font-size: 0.8rem;
+}
+
+/* ===== Round Scores ===== */
+.scores-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-size: 0.8rem;
+  color: #b8d4c0;
+  margin-bottom: 10px;
+}
+
+/* ===== Hand Area ===== */
+.hand-area {
+  margin-top: auto;
+  background: rgba(248, 245, 240, 0.95);
+  border-radius: 12px 12px 0 0;
+  padding: 14px 16px 20px;
+  box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.2);
+}
+
+.hand-area h4 {
+  margin: 0 0 8px 0;
+  font-size: 0.9rem;
+  color: #2c3e50;
+}
+
+.hand-cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2px;
+}
+
+/* ===== Friend Calling Form ===== */
+.friend-call-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 8px;
+  flex-wrap: wrap;
+}
+
+.friend-call-row select {
+  padding: 6px 10px;
+  border-radius: 6px;
+  border: 1px solid #bdc3c7;
+  font-size: 0.9rem;
+}
+
+/* ===== Round Result / Game Over ===== */
+.result-card {
+  background: rgba(248, 245, 240, 0.95);
+  border-radius: 12px;
+  padding: 24px;
+  margin-bottom: 12px;
+  text-align: center;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+}
+
+.result-card h3 {
+  margin: 0 0 12px 0;
+  font-size: 1.4rem;
+  color: #2c3e50;
+}
+
+.result-card.game-over {
+  background: linear-gradient(135deg, #d5f5e3, #abebc6);
+  border: 2px solid #27ae60;
+}
+
+.level-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: center;
+  margin: 10px 0;
+}
+
+.level-chip {
+  padding: 4px 10px;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  background: #f2f3f4;
+}
+
+.level-chip.promoted {
+  background: #d5f5e3;
+  font-weight: 600;
+}
+
+.level-chip.winner {
+  background: #27ae60;
+  color: #fff;
+  font-weight: bold;
+}
+
+/* ===== Suit Picker Buttons ===== */
+.suit-picker {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.suit-btn {
+  padding: 8px 18px;
+  font-size: 1.3rem;
+  cursor: pointer;
+  border-radius: 8px;
+  border: 2px solid #ddd;
+  background: #fff;
+  transition: border-color 0.2s, background-color 0.2s;
+}
+
+.suit-btn:hover {
+  border-color: #e67e22;
+  background: #fef5e7;
+}
+
+/* ===== Responsive ===== */
+@media (max-width: 640px) {
+  .game-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
   }
-  to {
-    transform: rotate(360deg);
+
+  .game-header-right {
+    text-align: left;
+  }
+
+  .form-card {
+    padding: 20px 20px;
+  }
+
+  .lobby-card {
+    padding: 24px 20px;
+  }
+
+  .result-card {
+    padding: 16px;
+  }
+
+  .friend-call-row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .hand-area {
+    padding: 10px 8px 16px;
+  }
+}
+
+@media (max-width: 400px) {
+  .home-title {
+    font-size: 1.6rem;
+  }
+
+  .game-code-display {
+    font-size: 1.1rem;
+    padding: 6px 14px;
+  }
+
+  .players-bar {
+    gap: 4px;
+  }
+
+  .player-chip {
+    font-size: 0.75rem;
+    padding: 4px 8px;
   }
 }

--- a/frontend_code/src/App.css
+++ b/frontend_code/src/App.css
@@ -129,6 +129,24 @@
   margin-top: 8px;
 }
 
+.btn-leave {
+  background: none;
+  border: 1px solid #bdc3c7;
+  color: #7f8c8d;
+  padding: 4px 12px;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: background-color 0.2s, color 0.2s;
+  margin-top: 6px;
+}
+
+.btn-leave:hover {
+  background: #e74c3c;
+  border-color: #e74c3c;
+  color: #fff;
+}
+
 /* ===== Lobby ===== */
 .lobby-container {
   display: flex;

--- a/frontend_code/src/App.js
+++ b/frontend_code/src/App.js
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 
 import CreateGame from './components/CreateGame';
 import Lobby from './components/Lobby';
@@ -7,32 +7,75 @@ import Game from './components/Game';
 import './App.css';
 
 function App() {
-  const [sessionInfo, setSessionInfo] = useState({
-    'game_code': '',
-    'user_name': '',
-    'user_uuid': '',
-    'game_link': '',
-    'host': false
-  })
+  const [sessionInfo, setSessionInfo] = useState(() => {
+    // Restore session from localStorage on page load
+    const saved = localStorage.getItem('findingFriendsSession');
+    if (saved) {
+      try { return JSON.parse(saved); } catch {}
+    }
+    return { game_code: '', user_name: '', user_uuid: '', game_link: '', host: false };
+  });
 
   const [gameStarted, setGameStarted] = useState(false);
   const [inLobby, setLobby] = useState(false);
   const [initialGameState, setInitialGameState] = useState(null);
   const socketRef = useRef(null);
 
+  // Persist session info to localStorage
+  useEffect(() => {
+    if (sessionInfo.game_code && sessionInfo.user_uuid) {
+      localStorage.setItem('findingFriendsSession', JSON.stringify(sessionInfo));
+    }
+  }, [sessionInfo]);
+
+  // Auto-rejoin: if we have session info on mount, try to fetch current game state
+  useEffect(() => {
+    if (sessionInfo.game_code && sessionInfo.user_uuid && !inLobby && !gameStarted) {
+      fetch(`/game/${sessionInfo.game_code}/player/${sessionInfo.user_uuid}`)
+        .then(res => {
+          if (!res.ok) throw new Error('Game not found');
+          return res.json();
+        })
+        .then(data => {
+          if (data.game_event_state && data.game_event_state !== 'waiting-for-player-to-join') {
+            // Game is in progress, go straight to Game
+            setInitialGameState(data);
+            setGameStarted(true);
+          } else if (data.game_event_state) {
+            // Still in lobby
+            setLobby(true);
+          }
+        })
+        .catch(() => {
+          // Game no longer exists, clear saved session
+          localStorage.removeItem('findingFriendsSession');
+          setSessionInfo({ game_code: '', user_name: '', user_uuid: '', game_link: '', host: false });
+        });
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
   const updateSessionInfo = (key, new_value) => {
     setSessionInfo(prev => ({...prev, [key]: new_value}));
-  }
+  };
 
   const updateInLobby = (lobby) => {
     setLobby(lobby);
-  }
+  };
 
   const handleGameStarted = (gameStateData, socket) => {
     setInitialGameState(gameStateData);
     socketRef.current = socket;
     setGameStarted(true);
-  }
+  };
+
+  const handleLeaveGame = () => {
+    localStorage.removeItem('findingFriendsSession');
+    setSessionInfo({ game_code: '', user_name: '', user_uuid: '', game_link: '', host: false });
+    setGameStarted(false);
+    setLobby(false);
+    setInitialGameState(null);
+    socketRef.current = null;
+  };
 
   if (gameStarted) {
     return (
@@ -41,6 +84,7 @@ function App() {
           sessionInfo={sessionInfo}
           initialGameState={initialGameState}
           socket={socketRef.current}
+          onLeaveGame={handleLeaveGame}
         />
       </div>
     );
@@ -59,8 +103,12 @@ function App() {
 
   return (
     <div className="App">
-      <CreateGame updateSessionInfo={updateSessionInfo} updateLobby={updateInLobby} />
-      <JoinGame updateSessionInfo={updateSessionInfo} updateLobby={updateInLobby} />
+      <div className="home-screen">
+        <h1 className="home-title">Finding Friends</h1>
+        <p className="home-subtitle">Zhao Pengyou &middot; 找朋友</p>
+        <CreateGame updateSessionInfo={updateSessionInfo} updateLobby={updateInLobby} />
+        <JoinGame updateSessionInfo={updateSessionInfo} updateLobby={updateInLobby} />
+      </div>
     </div>
   );
 }

--- a/frontend_code/src/App.js
+++ b/frontend_code/src/App.js
@@ -96,6 +96,7 @@ function App() {
         <Lobby
           sessionInfo={sessionInfo}
           onGameStarted={handleGameStarted}
+          onLeaveGame={handleLeaveGame}
         />
       </div>
     );

--- a/frontend_code/src/components/Card.js
+++ b/frontend_code/src/components/Card.js
@@ -8,12 +8,12 @@ const SUIT_SYMBOLS = {
 };
 
 const SUIT_COLORS = {
-    'HEART': '#e74c3c',
-    'DIAMOND': '#e74c3c',
+    'HEART': '#c0392b',
+    'DIAMOND': '#c0392b',
     'CLUB': '#2c3e50',
     'SPADE': '#2c3e50',
     'SMALL': '#2c3e50',
-    'BIG': '#e74c3c',
+    'BIG': '#c0392b',
 };
 
 const RANK_DISPLAY = {
@@ -46,9 +46,9 @@ const Card = ({ card, selected, onClick }) => {
         flexDirection: 'column',
         alignItems: 'center',
         justifyContent: 'center',
-        width: '60px',
-        height: '90px',
-        border: selected ? '3px solid #3498db' : '1px solid #bdc3c7',
+        width: '56px',
+        height: '84px',
+        border: selected ? '2px solid #3498db' : '1px solid #d5d8dc',
         borderRadius: '8px',
         backgroundColor: selected ? '#ebf5fb' : '#fff',
         color: color,
@@ -56,19 +56,32 @@ const Card = ({ card, selected, onClick }) => {
         fontWeight: 'bold',
         cursor: onClick ? 'pointer' : 'default',
         margin: '2px',
-        boxShadow: selected ? '0 0 6px rgba(52,152,219,0.5)' : '0 1px 3px rgba(0,0,0,0.15)',
+        boxShadow: selected
+            ? '0 0 8px rgba(52,152,219,0.5), 0 2px 4px rgba(0,0,0,0.1)'
+            : '0 1px 3px rgba(0,0,0,0.12)',
         userSelect: 'none',
-        transition: 'transform 0.1s, box-shadow 0.1s',
+        transition: 'transform 0.1s, box-shadow 0.15s, border-color 0.15s',
+        position: 'relative',
     };
 
+    if (onClick) {
+        cardStyle[':hover'] = { transform: 'translateY(-4px)' };
+    }
+
     return (
-        <div style={cardStyle} onClick={onClick} title={`${rankDisplay} ${suitSymbol}`}>
+        <div
+            style={cardStyle}
+            onClick={onClick}
+            title={`${rankDisplay} ${suitSymbol}`}
+            onMouseEnter={onClick ? (e) => { e.currentTarget.style.transform = 'translateY(-6px)'; } : undefined}
+            onMouseLeave={onClick ? (e) => { e.currentTarget.style.transform = 'translateY(0)'; } : undefined}
+        >
             {isJoker ? (
-                <span style={{ fontSize: '20px' }}>{suitSymbol}</span>
+                <span style={{ fontSize: '18px' }}>{suitSymbol}</span>
             ) : (
                 <>
-                    <span style={{ fontSize: '16px' }}>{rankDisplay}</span>
-                    <span style={{ fontSize: '18px' }}>{suitSymbol}</span>
+                    <span style={{ fontSize: '15px', lineHeight: 1 }}>{rankDisplay}</span>
+                    <span style={{ fontSize: '17px', lineHeight: 1, marginTop: '2px' }}>{suitSymbol}</span>
                 </>
             )}
         </div>

--- a/frontend_code/src/components/CreateGame.js
+++ b/frontend_code/src/components/CreateGame.js
@@ -1,21 +1,12 @@
-import React, { useState } from "react";
+import { useState } from "react";
 
 const CreateGame = (props) => {
-
     const [nickName, setNickName] = useState('');
-
-    const [gameInfo, setGameInfo] = useState({
-        'game_code': '',
-        'join_link': ''
-    });
-
-    const onChangeNickName = (event) => {
-        setNickName(event.target.value);
-    }
+    const [error, setError] = useState('');
 
     const joinGame = (game_code, nickName) => {
-        fetch('/join/' +game_code + '?nick_name='+nickName).then((res) => 
-            res.json().then((data)=> {
+        fetch('/join/' + game_code + '?nick_name=' + nickName).then((res) =>
+            res.json().then((data) => {
                 props.updateSessionInfo('game_code', game_code);
                 props.updateSessionInfo('user_name', nickName);
                 props.updateSessionInfo('user_uuid', data.new_player_uuid);
@@ -26,34 +17,39 @@ const CreateGame = (props) => {
         );
     }
 
-
     const onSubmit = (event) => {
         event.preventDefault();
-        fetch("/create").then((res) =>{
+        setError('');
+        if (!nickName.trim()) {
+            setError('Please enter a nickname');
+            return;
+        }
+        fetch("/create").then((res) => {
+            if (!res.ok) throw new Error('Failed to create game');
             res.json().then((data) => {
-                console.log(data)
-                joinGame(data.game_code, nickName)
-                setGameInfo({
-                    game_code: data.game_code,
-                    join_link: data.link,
-                });
+                joinGame(data.game_code, nickName);
             })
-        });
-
+        }).catch(err => setError(err.message || 'Failed to create game'));
     }
 
     return (
-        <div>
+        <div className="form-card">
+            <h3>Create New Game</h3>
             <form onSubmit={onSubmit}>
-            <p>Create Game</p>
-            <label htmlFor="nick_name">NickName:</label>
-            <input type="text" id="nick_name" name="nick_name" onChange={(e) => onChangeNickName(e)} />
-            <br/>
-            <input type="submit" value="Submit" />
+                <label htmlFor="create_nick">Nickname</label>
+                <input
+                    type="text"
+                    id="create_nick"
+                    name="nick_name"
+                    value={nickName}
+                    onChange={(e) => setNickName(e.target.value)}
+                    placeholder="Enter your name"
+                />
+                <button type="submit" className="btn btn-primary">Create Game</button>
             </form>
+            {error && <p className="error-text">{error}</p>}
         </div>
-    )
+    );
 }
-
 
 export default CreateGame;

--- a/frontend_code/src/components/Game.js
+++ b/frontend_code/src/components/Game.js
@@ -219,6 +219,9 @@ const Game = ({ sessionInfo, initialGameState, socket: externalSocket, onLeaveGa
                     {trumpSuit && <div className="trump-info">Trump: {trumpRank} of {SUIT_SYMBOLS[trumpSuit] || trumpSuit}</div>}
                     {myLevel && <div style={{ fontSize: '0.85rem' }}>Your Level: {RANK_DISPLAY[myLevel] || myLevel}</div>}
                     {isAlpha && <div className="alpha-badge">You are the Alpha</div>}
+                    {onLeaveGame && (
+                        <button className="btn-leave" onClick={onLeaveGame}>Leave Game</button>
+                    )}
                 </div>
             </div>
 

--- a/frontend_code/src/components/Game.js
+++ b/frontend_code/src/components/Game.js
@@ -1,4 +1,5 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
+import { io } from "socket.io-client";
 import Card from "./Card";
 
 const PHASE_LABELS = {
@@ -8,6 +9,15 @@ const PHASE_LABELS = {
     'round-started': 'Round in Progress',
     'round-ended': 'Round Ended',
     'game-ended': 'Game Over',
+};
+
+const PHASE_CLASSES = {
+    'waiting-on-alpha-choose-trump': 'trump',
+    'waiting-on-alpha-friend-card-choice': 'friend',
+    'waiting-on-alpha-kitty-sort': 'kitty',
+    'round-started': 'playing',
+    'round-ended': 'ended',
+    'game-ended': 'ended',
 };
 
 const SUIT_SYMBOLS = {
@@ -30,33 +40,54 @@ const RANK_OPTIONS = [
     'FOUR', 'THREE', 'TWO',
 ];
 
-const Game = ({ sessionInfo, initialGameState, socket }) => {
+const Game = ({ sessionInfo, initialGameState, socket: externalSocket, onLeaveGame }) => {
     const [gameState, setGameState] = useState(initialGameState || {});
     const [selectedCardIdx, setSelectedCardIdx] = useState(null);
     const [selectedCardIndices, setSelectedCardIndices] = useState(new Set());
-    // Friend calling state: array of {suit, rank, order}
+    const [errorMessage, setErrorMessage] = useState('');
     const [callingCards, setCallingCards] = useState([]);
     const player_uuid = sessionInfo['user_uuid'];
+    const game_code = sessionInfo['game_code'];
+    const ownSocketRef = useRef(null);
+
+    const socket = externalSocket || ownSocketRef.current;
 
     useEffect(() => {
-        if (!socket) return;
+        if (externalSocket) return;
+        const newSocket = io("http://127.0.0.1:5050", { transports: ["websocket"] });
+        ownSocketRef.current = newSocket;
+        newSocket.on("connect", () => {
+            console.log("Game reconnected to websocket");
+            newSocket.emit('join', { game_code, player_uuid });
+        });
+        newSocket.on("disconnect", () => console.log("Game disconnected from websocket"));
+        return () => newSocket.disconnect();
+    }, [externalSocket, game_code, player_uuid]);
 
+    useEffect(() => {
+        const activeSocket = externalSocket || ownSocketRef.current;
+        if (!activeSocket) return;
         const handleGameStats = (data) => {
-            console.log('Game received game_stats', data);
             setGameState(data);
             setSelectedCardIdx(null);
             setSelectedCardIndices(new Set());
+            setErrorMessage('');
         };
-
-        socket.on('game_stats', handleGameStats);
-
+        const handleError = (data) => {
+            console.error('Server error:', data);
+            setErrorMessage(data.message || 'An error occurred');
+        };
+        activeSocket.on('game_stats', handleGameStats);
+        activeSocket.on('error', handleError);
         return () => {
-            socket.off('game_stats', handleGameStats);
+            activeSocket.off('game_stats', handleGameStats);
+            activeSocket.off('error', handleError);
         };
-    }, [socket]);
+    }, [externalSocket]);
 
     const phase = gameState.game_event_state || '';
     const phaseLabel = PHASE_LABELS[phase] || phase;
+    const phaseClass = PHASE_CLASSES[phase] || '';
     const playerList = gameState.player_list || [];
     const hand = gameState.player_hand || [];
     const activePile = gameState.cards_in_active_pile || [];
@@ -72,7 +103,6 @@ const Game = ({ sessionInfo, initialGameState, socket }) => {
     const leadingHand = gameState.leading_hand_of_subround || [];
     const revealedFriends = gameState.revealed_friends || [];
     const onAlphaTeam = gameState.on_alpha_team || false;
-    const winningPlayer = gameState.winning_player_of_round;
     const roundWinnerSide = gameState.round_winner_side || '';
     const roundDefenderPoints = gameState.round_defender_points || 0;
     const roundPromotionLevels = gameState.round_promotion_levels || 0;
@@ -81,14 +111,11 @@ const Game = ({ sessionInfo, initialGameState, socket }) => {
     const isHost = gameState.hosting || false;
     const playerLevels = gameState.player_levels || {};
 
-    // --- Trump Declaration Logic ---
+    // --- Trump Declaration ---
     const isTrumpPhase = phase === 'waiting-on-alpha-choose-trump';
     const canDeclareTrump = isTrumpPhase && isAlpha;
 
-    const isEligibleTrumpCard = (card) => {
-        if (!canDeclareTrump) return false;
-        return card.rank === myLevel;
-    };
+    const isEligibleTrumpCard = (card) => canDeclareTrump && card.rank === myLevel;
 
     const eligibleSuits = {};
     if (canDeclareTrump) {
@@ -100,33 +127,23 @@ const Game = ({ sessionInfo, initialGameState, socket }) => {
     }
 
     const handleCardClick = (idx) => {
-        if (canDeclareTrump && isEligibleTrumpCard(hand[idx])) {
-            setSelectedCardIdx(idx);
-        }
+        if (canDeclareTrump && isEligibleTrumpCard(hand[idx])) setSelectedCardIdx(idx);
     };
 
     const handleDeclareTrump = () => {
         if (selectedCardIdx === null || !socket) return;
         const card = hand[selectedCardIdx];
-        socket.emit('declare_trump', {
-            game_code: sessionInfo['game_code'],
-            player_uuid: player_uuid,
-            suit: card.suit,
-            rank: card.rank,
-        });
+        socket.emit('declare_trump', { game_code, player_uuid, suit: card.suit, rank: card.rank });
         setSelectedCardIdx(null);
     };
 
-    // --- Friend Calling Logic ---
+    // --- Friend Calling ---
     const isFriendPhase = phase === 'waiting-on-alpha-friend-card-choice';
     const canCallFriends = isFriendPhase && isAlpha;
 
-    // Initialize calling cards slots when entering friend phase
     useEffect(() => {
         if (canCallFriends && callingCards.length !== numFriendsToCall) {
-            setCallingCards(
-                Array.from({ length: numFriendsToCall }, () => ({ suit: 'CLUB', rank: 'ACE', order: 1 }))
-            );
+            setCallingCards(Array.from({ length: numFriendsToCall }, () => ({ suit: 'CLUB', rank: 'ACE', order: 1 })));
         }
     }, [canCallFriends, numFriendsToCall, callingCards.length]);
 
@@ -140,14 +157,10 @@ const Game = ({ sessionInfo, initialGameState, socket }) => {
 
     const handleCallFriends = () => {
         if (!socket) return;
-        socket.emit('call_friends', {
-            game_code: sessionInfo['game_code'],
-            player_uuid: player_uuid,
-            calling_cards: callingCards,
-        });
+        socket.emit('call_friends', { game_code, player_uuid, calling_cards: callingCards });
     };
 
-    // --- Kitty Exchange Logic ---
+    // --- Kitty Exchange ---
     const isKittyPhase = phase === 'waiting-on-alpha-kitty-sort';
     const canExchangeKitty = isKittyPhase && isAlpha;
 
@@ -155,37 +168,21 @@ const Game = ({ sessionInfo, initialGameState, socket }) => {
         if (!canExchangeKitty) return;
         setSelectedCardIndices(prev => {
             const next = new Set(prev);
-            if (next.has(idx)) {
-                next.delete(idx);
-            } else {
-                // Only allow selecting up to kittySize cards
-                // kittySize is 0 during kitty phase (cards are in hand now),
-                // but we know the kitty was added, so use card_out_of_play count or calculate
-                if (next.size < kittySize) {
-                    next.add(idx);
-                }
-            }
+            if (next.has(idx)) next.delete(idx);
+            else if (next.size < kittySize) next.add(idx);
             return next;
         });
     };
 
     const handleKittyExchange = () => {
         if (!socket) return;
-        const discardedCards = Array.from(selectedCardIndices).map(idx => ({
-            suit: hand[idx].suit,
-            rank: hand[idx].rank,
-        }));
-        socket.emit('kitty_exchange', {
-            game_code: sessionInfo['game_code'],
-            player_uuid: player_uuid,
-            discarded_cards: discardedCards,
-        });
+        const discardedCards = Array.from(selectedCardIndices).map(idx => ({ suit: hand[idx].suit, rank: hand[idx].rank }));
+        socket.emit('kitty_exchange', { game_code, player_uuid, discarded_cards: discardedCards });
         setSelectedCardIndices(new Set());
     };
 
-    // --- Card Play Logic ---
+    // --- Card Play ---
     const isPlayPhase = phase === 'round-started';
-    // Leading player (leadingHand empty) can select 1+ cards; following must match count
     const isLeading = isPlayPhase && myTurn && leadingHand.length === 0;
     const cardsToPlay = isLeading ? null : (leadingHand.length || 1);
 
@@ -193,106 +190,77 @@ const Game = ({ sessionInfo, initialGameState, socket }) => {
         if (!isPlayPhase || !myTurn) return;
         setSelectedCardIndices(prev => {
             const next = new Set(prev);
-            if (next.has(idx)) {
-                next.delete(idx);
-            } else if (cardsToPlay === null || next.size < cardsToPlay) {
-                next.add(idx);
-            }
+            if (next.has(idx)) next.delete(idx);
+            else if (cardsToPlay === null || next.size < cardsToPlay) next.add(idx);
             return next;
         });
     };
 
     const handlePlayCard = () => {
         if (selectedCardIndices.size === 0 || !socket || !myTurn) return;
-        const cards = Array.from(selectedCardIndices).map(idx => ({
-            suit: hand[idx].suit,
-            rank: hand[idx].rank,
-        }));
-        socket.emit('play_cards', {
-            game_code: sessionInfo['game_code'],
-            player_uuid: player_uuid,
-            cards: cards,
-        });
+        const cards = Array.from(selectedCardIndices).map(idx => ({ suit: hand[idx].suit, rank: hand[idx].rank }));
+        socket.emit('play_cards', { game_code, player_uuid, cards });
         setSelectedCardIndices(new Set());
     };
 
-    // Determine which suits are NOT trump (for friend calling validation display)
     const nonTrumpSuits = NON_TRUMP_SUITS.filter(s => s !== trumpSuit);
     const nonTrumpRanks = RANK_OPTIONS.filter(r => r !== trumpRank);
 
     return (
-        <div style={{ padding: '20px', maxWidth: '900px', margin: '0 auto' }}>
+        <div className="game-container">
             {/* Header */}
-            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', borderBottom: '2px solid #ecf0f1', paddingBottom: '10px', marginBottom: '15px' }}>
-                <div>
-                    <h2 style={{ margin: 0 }}>Finding Friends</h2>
-                    <span style={{ color: '#7f8c8d', fontSize: '14px' }}>Game: {sessionInfo['game_code']}</span>
+            <div className="game-header">
+                <div className="game-header-left">
+                    <h2>Finding Friends</h2>
+                    <span className="game-code-small">Game: {game_code}</span>
                 </div>
-                <div style={{ textAlign: 'right' }}>
-                    <div style={{ fontWeight: 'bold', color: '#2c3e50' }}>{phaseLabel}</div>
-                    {trumpSuit && <div style={{ fontSize: '13px' }}>Trump: {trumpRank} of {SUIT_SYMBOLS[trumpSuit] || trumpSuit}</div>}
-                    {myLevel && <div style={{ fontSize: '13px' }}>Your Level: {RANK_DISPLAY[myLevel] || myLevel}</div>}
-                    {isAlpha && <div style={{ fontSize: '13px', color: '#e67e22' }}>You are the Alpha</div>}
-                    {kittySize > 0 && isTrumpPhase && (
-                        <div style={{ fontSize: '13px', color: '#7f8c8d' }}>Kitty: {kittySize} cards</div>
-                    )}
+                <div className="game-header-right">
+                    <span className={`phase-badge ${phaseClass}`}>{phaseLabel}</span>
+                    {trumpSuit && <div className="trump-info">Trump: {trumpRank} of {SUIT_SYMBOLS[trumpSuit] || trumpSuit}</div>}
+                    {myLevel && <div style={{ fontSize: '0.85rem' }}>Your Level: {RANK_DISPLAY[myLevel] || myLevel}</div>}
+                    {isAlpha && <div className="alpha-badge">You are the Alpha</div>}
                 </div>
             </div>
 
-            {/* Players */}
-            <div style={{ marginBottom: '15px' }}>
-                <h4 style={{ margin: '0 0 8px 0' }}>Players</h4>
-                <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
-                    {playerList.map((player, idx) => {
-                        const isCurrent = currentPlayer && currentPlayer.uuid === player.uuid;
-                        const isMe = player.uuid === player_uuid;
-                        return (
-                            <div key={player.uuid || idx} style={{
-                                padding: '6px 12px',
-                                borderRadius: '6px',
-                                border: isCurrent ? '2px solid #e67e22' : '1px solid #bdc3c7',
-                                backgroundColor: isMe ? '#eaf2f8' : '#fff',
-                                fontSize: '13px',
-                            }}>
-                                {player.name}
-                                {isMe && ' (you)'}
-                                {isCurrent && ' \u25C0'}
-                            </div>
-                        );
-                    })}
-                </div>
+            {/* Players bar */}
+            <div className="players-bar">
+                {playerList.map((player, idx) => {
+                    const isCurrent = currentPlayer && currentPlayer.uuid === player.uuid;
+                    const isMe = player.uuid === player_uuid;
+                    return (
+                        <div key={player.uuid || idx} className={`player-chip${isCurrent ? ' is-current' : ''}${isMe ? ' is-me' : ''}`}>
+                            {player.name}
+                            {isMe && ' (you)'}
+                            {isCurrent && ' \u25C0'}
+                        </div>
+                    );
+                })}
             </div>
 
-            {/* Trump declaration UI */}
-            {isTrumpPhase && !isAlpha && (
-                <div style={{ marginBottom: '10px', padding: '10px', backgroundColor: '#fef9e7', borderRadius: '6px' }}>
-                    Waiting for the alpha player to declare trump...
+            {/* Error banner */}
+            {errorMessage && (
+                <div className="info-panel error">
+                    <span>{errorMessage}</span>
+                    <button className="close-btn" onClick={() => setErrorMessage('')}>✕</button>
                 </div>
             )}
+
+            {/* Trump declaration */}
+            {isTrumpPhase && !isAlpha && (
+                <div className="info-panel waiting">Waiting for the alpha player to declare trump...</div>
+            )}
             {canDeclareTrump && (
-                <div style={{ marginBottom: '15px', padding: '15px', backgroundColor: '#fdf2e9', borderRadius: '8px' }}>
-                    <strong>Declare Trump Suit</strong>
-                    <p style={{ margin: '8px 0', fontSize: '14px' }}>
-                        Your level is <strong>{myLevel}</strong>. Click a matching card below to select a trump suit, then confirm.
-                    </p>
+                <div className="info-panel action">
+                    <h4>Declare Trump Suit</h4>
+                    <p>Your level is <strong>{RANK_DISPLAY[myLevel] || myLevel}</strong>. Click a matching card below to select a trump suit, then confirm.</p>
                     {Object.keys(eligibleSuits).length === 0 && (
                         <>
-                            <p style={{ color: '#e74c3c', fontSize: '14px' }}>
-                                You have no cards matching your level. Pick any suit:
-                            </p>
-                            <div style={{ display: 'flex', gap: '8px', marginBottom: '10px' }}>
+                            <p className="error-text">You have no cards matching your level. Pick any suit:</p>
+                            <div className="suit-picker">
                                 {NON_TRUMP_SUITS.map(suit => (
-                                    <button key={suit} onClick={() => {
+                                    <button key={suit} className="suit-btn" onClick={() => {
                                         if (!socket) return;
-                                        socket.emit('declare_trump', {
-                                            game_code: sessionInfo['game_code'],
-                                            player_uuid: player_uuid,
-                                            suit: suit,
-                                            rank: myLevel,
-                                        });
-                                    }} style={{
-                                        padding: '8px 16px', fontSize: '18px', cursor: 'pointer',
-                                        borderRadius: '6px', border: '1px solid #bdc3c7', backgroundColor: '#fff',
+                                        socket.emit('declare_trump', { game_code, player_uuid, suit, rank: myLevel });
                                     }}>
                                         {SUIT_SYMBOLS[suit]}
                                     </button>
@@ -301,67 +269,48 @@ const Game = ({ sessionInfo, initialGameState, socket }) => {
                         </>
                     )}
                     {selectedCardIdx !== null && (
-                        <button onClick={handleDeclareTrump} style={{
-                            padding: '8px 20px', fontSize: '15px', cursor: 'pointer',
-                            borderRadius: '6px', backgroundColor: '#e67e22', color: '#fff',
-                            border: 'none', marginTop: '8px',
-                        }}>
+                        <button className="btn btn-orange" onClick={handleDeclareTrump}>
                             Declare {SUIT_SYMBOLS[hand[selectedCardIdx]?.suit] || ''} as Trump
                         </button>
                     )}
                 </div>
             )}
 
-            {/* Friend Calling UI */}
+            {/* Friend Calling */}
             {isFriendPhase && !isAlpha && (
-                <div style={{ marginBottom: '10px', padding: '10px', backgroundColor: '#fef9e7', borderRadius: '6px' }}>
+                <div className="info-panel waiting">
                     Trump: <strong>{SUIT_SYMBOLS[trumpSuit] || trumpSuit} {trumpRank}</strong>. Waiting for alpha to call friends...
                 </div>
             )}
             {canCallFriends && (
-                <div style={{ marginBottom: '15px', padding: '15px', backgroundColor: '#eaf2f8', borderRadius: '8px' }}>
-                    <strong>Call {numFriendsToCall} Friend Card{numFriendsToCall > 1 ? 's' : ''}</strong>
-                    <p style={{ margin: '8px 0', fontSize: '14px' }}>
-                        Specify which cards will reveal your secret partners. Called cards must not be trumps.
-                    </p>
+                <div className="info-panel action-blue">
+                    <h4>Call {numFriendsToCall} Friend Card{numFriendsToCall > 1 ? 's' : ''}</h4>
+                    <p>Specify which cards will reveal your secret partners. Called cards must not be trumps.</p>
                     {callingCards.map((cc, idx) => (
-                        <div key={idx} style={{ display: 'flex', gap: '8px', alignItems: 'center', marginBottom: '8px' }}>
-                            <span style={{ fontWeight: 'bold', minWidth: '20px' }}>#{idx + 1}</span>
-                            <select value={cc.order} onChange={e => updateCallingCard(idx, 'order', parseInt(e.target.value))}
-                                style={{ padding: '4px 8px' }}>
+                        <div key={idx} className="friend-call-row">
+                            <span style={{ fontWeight: 'bold' }}>#{idx + 1}</span>
+                            <select value={cc.order} onChange={e => updateCallingCard(idx, 'order', parseInt(e.target.value))}>
                                 <option value={1}>1st</option>
                                 <option value={2}>2nd</option>
                                 <option value={3}>3rd</option>
                                 <option value={4}>4th</option>
                             </select>
-                            <select value={cc.rank} onChange={e => updateCallingCard(idx, 'rank', e.target.value)}
-                                style={{ padding: '4px 8px' }}>
-                                {nonTrumpRanks.map(r => (
-                                    <option key={r} value={r}>{r}</option>
-                                ))}
+                            <select value={cc.rank} onChange={e => updateCallingCard(idx, 'rank', e.target.value)}>
+                                {nonTrumpRanks.map(r => <option key={r} value={r}>{r}</option>)}
                             </select>
                             <span>of</span>
-                            <select value={cc.suit} onChange={e => updateCallingCard(idx, 'suit', e.target.value)}
-                                style={{ padding: '4px 8px' }}>
-                                {nonTrumpSuits.map(s => (
-                                    <option key={s} value={s}>{SUIT_SYMBOLS[s]} {s}</option>
-                                ))}
+                            <select value={cc.suit} onChange={e => updateCallingCard(idx, 'suit', e.target.value)}>
+                                {nonTrumpSuits.map(s => <option key={s} value={s}>{SUIT_SYMBOLS[s]} {s}</option>)}
                             </select>
                         </div>
                     ))}
-                    <button onClick={handleCallFriends} style={{
-                        padding: '8px 20px', fontSize: '15px', cursor: 'pointer',
-                        borderRadius: '6px', backgroundColor: '#2980b9', color: '#fff',
-                        border: 'none', marginTop: '8px',
-                    }}>
-                        Confirm Friend Cards
-                    </button>
+                    <button className="btn btn-secondary" onClick={handleCallFriends}>Confirm Friend Cards</button>
                 </div>
             )}
 
-            {/* Called cards display (visible to everyone after calling) */}
+            {/* Called cards strip */}
             {friendCallingCards.length > 0 && phase !== 'waiting-on-alpha-friend-card-choice' && (
-                <div style={{ marginBottom: '10px', padding: '10px', backgroundColor: '#f5f5f5', borderRadius: '6px', fontSize: '13px' }}>
+                <div className="meta-strip">
                     <strong>Called Cards:</strong>{' '}
                     {friendCallingCards.map((cc, idx) => (
                         <span key={idx}>
@@ -373,51 +322,37 @@ const Game = ({ sessionInfo, initialGameState, socket }) => {
                 </div>
             )}
 
-            {/* Kitty Exchange UI */}
+            {/* Kitty Exchange */}
             {isKittyPhase && !isAlpha && (
-                <div style={{ marginBottom: '10px', padding: '10px', backgroundColor: '#fef9e7', borderRadius: '6px' }}>
-                    Waiting for alpha to exchange kitty cards...
-                </div>
+                <div className="info-panel waiting">Waiting for alpha to exchange kitty cards...</div>
             )}
             {canExchangeKitty && (
-                <div style={{ marginBottom: '15px', padding: '15px', backgroundColor: '#fdf2e9', borderRadius: '8px' }}>
-                    <strong>Kitty Exchange</strong>
-                    <p style={{ margin: '8px 0', fontSize: '14px' }}>
-                        The kitty ({kittySize} cards) has been added to your hand. Select {kittySize} cards to discard face-down.
-                    </p>
-                    <p style={{ fontSize: '13px', color: '#7f8c8d' }}>
-                        Selected: {selectedCardIndices.size} / {kittySize}
-                    </p>
+                <div className="info-panel action">
+                    <h4>Kitty Exchange</h4>
+                    <p>The kitty ({kittySize} cards) has been added to your hand. Select {kittySize} cards to discard face-down.</p>
+                    <p style={{ color: '#7f8c8d', fontSize: '0.85rem' }}>Selected: {selectedCardIndices.size} / {kittySize}</p>
                     {selectedCardIndices.size === kittySize && (
-                        <button onClick={handleKittyExchange} style={{
-                            padding: '8px 20px', fontSize: '15px', cursor: 'pointer',
-                            borderRadius: '6px', backgroundColor: '#27ae60', color: '#fff',
-                            border: 'none', marginTop: '4px',
-                        }}>
-                            Confirm Discard
-                        </button>
+                        <button className="btn btn-primary" onClick={handleKittyExchange}>Confirm Discard</button>
                     )}
                 </div>
             )}
 
             {/* Trick area */}
             {activePile.length > 0 && (
-                <div style={{ marginBottom: '15px', padding: '15px', backgroundColor: '#f0f3f4', borderRadius: '8px' }}>
-                    <h4 style={{ margin: '0 0 8px 0' }}>Current Trick</h4>
-                    <div style={{ display: 'flex', flexWrap: 'wrap' }}>
-                        {activePile.map((card, idx) => (
-                            <Card key={idx} card={card} selected={false} />
-                        ))}
+                <div className="trick-area">
+                    <h4>Current Trick</h4>
+                    <div className="trick-cards">
+                        {activePile.map((card, idx) => <Card key={idx} card={card} selected={false} />)}
                     </div>
                 </div>
             )}
 
             {/* Turn indicator + Play button */}
             {phase === 'round-started' && (
-                <div style={{ marginBottom: '10px' }}>
-                    <div style={{ fontSize: '14px', fontWeight: 'bold', marginBottom: '6px' }}>
+                <div>
+                    <div className={`turn-indicator ${myTurn ? 'your-turn' : 'waiting-turn'}`}>
                         {myTurn
-                            ? <span style={{ color: '#27ae60' }}>
+                            ? <>
                                 {isLeading
                                     ? `It's your turn to lead! Select 1 or more cards.`
                                     : `It's your turn! Select ${cardsToPlay > 1 ? `${cardsToPlay} cards` : 'a card'} to play.`
@@ -426,16 +361,12 @@ const Game = ({ sessionInfo, initialGameState, socket }) => {
                                     ? ` (${selectedCardIndices.size} selected)`
                                     : ` (${selectedCardIndices.size}/${cardsToPlay} selected)`
                                 )}
-                              </span>
-                            : <span style={{ color: '#7f8c8d' }}>Waiting for {currentPlayer?.name || '...'} to play...</span>
+                              </>
+                            : `Waiting for ${currentPlayer?.name || '...'} to play...`
                         }
                     </div>
                     {myTurn && selectedCardIndices.size > 0 && (cardsToPlay === null || selectedCardIndices.size === cardsToPlay) && (
-                        <button onClick={handlePlayCard} style={{
-                            padding: '8px 20px', fontSize: '15px', cursor: 'pointer',
-                            borderRadius: '6px', backgroundColor: '#27ae60', color: '#fff',
-                            border: 'none',
-                        }}>
+                        <button className="btn btn-primary" style={{ width: 'auto', marginBottom: '10px' }} onClick={handlePlayCard}>
                             Play {selectedCardIndices.size} card{selectedCardIndices.size > 1 ? 's' : ''}
                         </button>
                     )}
@@ -444,7 +375,7 @@ const Game = ({ sessionInfo, initialGameState, socket }) => {
 
             {/* Revealed friends */}
             {revealedFriends.length > 0 && (
-                <div style={{ marginBottom: '10px', padding: '8px', backgroundColor: '#e8f8f5', borderRadius: '6px', fontSize: '13px' }}>
+                <div className="meta-strip" style={{ background: 'rgba(232, 248, 245, 0.9)' }}>
                     <strong>Revealed Friends:</strong>{' '}
                     {revealedFriends.map((uuid, idx) => {
                         const p = playerList.find(pl => pl.uuid === uuid);
@@ -453,16 +384,23 @@ const Game = ({ sessionInfo, initialGameState, socket }) => {
                 </div>
             )}
 
+            {/* Round scores */}
+            {gameState.players_round_score && Object.keys(gameState.players_round_score).length > 0 && phase === 'round-started' && (
+                <div className="scores-bar">
+                    {playerList.map((player) => (
+                        <span key={player.uuid}>
+                            {player.name}: {gameState.players_round_score[player.uuid] || 0} pts
+                        </span>
+                    ))}
+                </div>
+            )}
+
             {/* Round ended summary */}
             {phase === 'round-ended' && (
-                <div style={{ marginBottom: '15px', padding: '15px', backgroundColor: '#fef9e7', borderRadius: '8px' }}>
-                    <h3 style={{ margin: '0 0 10px 0' }}>Round Over!</h3>
-                    <p style={{ fontSize: '14px' }}>
-                        {onAlphaTeam
-                            ? 'You were on the Alpha team.'
-                            : 'You were on the Defender team.'}
-                    </p>
-                    <p style={{ fontSize: '14px' }}>
+                <div className="result-card">
+                    <h3>Round Over!</h3>
+                    <p>{onAlphaTeam ? 'You were on the Alpha team.' : 'You were on the Defender team.'}</p>
+                    <p>
                         Defender points: <strong>{roundDefenderPoints}</strong>
                         {' \u2014 '}
                         {roundWinnerSide === 'trump_maker' && <span style={{ color: '#27ae60' }}>Trump makers win!</span>}
@@ -470,7 +408,7 @@ const Game = ({ sessionInfo, initialGameState, socket }) => {
                         {roundWinnerSide === 'none' && <span style={{ color: '#7f8c8d' }}>Draw - no one advances.</span>}
                     </p>
                     {roundPromotionLevels > 0 && (
-                        <p style={{ fontSize: '14px' }}>
+                        <p>
                             <strong>+{roundPromotionLevels} level{roundPromotionLevels > 1 ? 's' : ''}</strong> for:{' '}
                             {roundPromotedPlayers.map((uuid, idx) => {
                                 const p = playerList.find(pl => pl.uuid === uuid);
@@ -478,98 +416,66 @@ const Game = ({ sessionInfo, initialGameState, socket }) => {
                             })}
                         </p>
                     )}
-                    <h4 style={{ margin: '8px 0 4px 0' }}>Player Levels</h4>
-                    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '10px', fontSize: '13px', marginBottom: '10px' }}>
+                    <h4>Player Levels</h4>
+                    <div className="level-chips">
                         {playerList.map(player => (
-                            <span key={player.uuid} style={{
-                                padding: '3px 8px', borderRadius: '4px',
-                                backgroundColor: roundPromotedPlayers.includes(player.uuid) ? '#d5f5e3' : '#f2f3f4',
-                            }}>
+                            <span key={player.uuid} className={`level-chip${roundPromotedPlayers.includes(player.uuid) ? ' promoted' : ''}`}>
                                 {player.name}: Lv {RANK_DISPLAY[playerLevels[player.uuid]] || playerLevels[player.uuid] || '?'}
                                 {' '}({gameState.players_round_score?.[player.uuid] || 0} pts)
                             </span>
                         ))}
                     </div>
                     {isHost && (
-                        <button onClick={() => {
+                        <button className="btn btn-orange" style={{ marginTop: '12px' }} onClick={() => {
                             if (!socket) return;
-                            socket.emit('next_round', {
-                                game_code: sessionInfo['game_code'],
-                                player_uuid: player_uuid,
-                            });
-                        }} style={{
-                            padding: '10px 24px', fontSize: '16px', cursor: 'pointer',
-                            borderRadius: '6px', backgroundColor: '#e67e22', color: '#fff',
-                            border: 'none', marginTop: '8px',
+                            socket.emit('next_round', { game_code, player_uuid });
                         }}>
                             Start Next Round
                         </button>
                     )}
-                    {!isHost && (
-                        <p style={{ fontSize: '13px', color: '#7f8c8d', marginTop: '8px' }}>
-                            Waiting for the host to start the next round...
-                        </p>
-                    )}
+                    {!isHost && <p style={{ color: '#7f8c8d', fontSize: '0.85rem', marginTop: '8px' }}>Waiting for the host to start the next round...</p>}
                 </div>
             )}
 
             {/* Game over */}
             {phase === 'game-ended' && (
-                <div style={{ marginBottom: '15px', padding: '20px', backgroundColor: '#d5f5e3', borderRadius: '8px', textAlign: 'center' }}>
-                    <h2 style={{ margin: '0 0 10px 0' }}>Game Over!</h2>
-                    <p style={{ fontSize: '16px' }}>
+                <div className="result-card game-over">
+                    <h3>Game Over!</h3>
+                    <p style={{ fontSize: '1.1rem' }}>
                         {(() => {
                             const winner = playerList.find(p => p.uuid === gameWinner);
                             return winner ? `${winner.name} has passed Ace and wins the game!` : 'A player has won!';
                         })()}
                     </p>
-                    <h4 style={{ margin: '12px 0 6px 0' }}>Final Levels</h4>
-                    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '10px', justifyContent: 'center', fontSize: '14px' }}>
+                    <h4>Final Levels</h4>
+                    <div className="level-chips">
                         {playerList.map(player => (
-                            <span key={player.uuid} style={{
-                                padding: '4px 10px', borderRadius: '4px',
-                                backgroundColor: player.uuid === gameWinner ? '#27ae60' : '#f2f3f4',
-                                color: player.uuid === gameWinner ? '#fff' : '#2c3e50',
-                                fontWeight: player.uuid === gameWinner ? 'bold' : 'normal',
-                            }}>
+                            <span key={player.uuid} className={`level-chip${player.uuid === gameWinner ? ' winner' : ''}`}>
                                 {player.name}: Lv {RANK_DISPLAY[playerLevels[player.uuid]] || playerLevels[player.uuid] || '?'}
                             </span>
                         ))}
                     </div>
-                </div>
-            )}
-
-            {/* Scores */}
-            {gameState.players_round_score && Object.keys(gameState.players_round_score).length > 0 && (
-                <div style={{ marginBottom: '15px' }}>
-                    <h4 style={{ margin: '0 0 8px 0' }}>Round Scores</h4>
-                    <div style={{ display: 'flex', gap: '12px', fontSize: '13px' }}>
-                        {playerList.map((player) => (
-                            <span key={player.uuid}>
-                                {player.name}: {gameState.players_round_score[player.uuid] || 0}
-                            </span>
-                        ))}
-                    </div>
+                    {onLeaveGame && (
+                        <button className="btn btn-primary" style={{ marginTop: '16px', width: 'auto' }} onClick={onLeaveGame}>
+                            Back to Home
+                        </button>
+                    )}
                 </div>
             )}
 
             {/* Hand */}
-            <div style={{ borderTop: '2px solid #ecf0f1', paddingTop: '15px' }}>
-                <h4 style={{ margin: '0 0 8px 0' }}>Your Hand ({hand.length} cards)</h4>
-                <div style={{ display: 'flex', flexWrap: 'wrap' }}>
+            <div className="hand-area">
+                <h4>Your Hand ({hand.length} cards)</h4>
+                <div className="hand-cards">
                     {hand.map((card, idx) => {
                         const eligible = isEligibleTrumpCard(card);
                         const selected = selectedCardIdx === idx || selectedCardIndices.has(idx);
                         const dimmed = canDeclareTrump && !eligible;
 
                         let onClick;
-                        if (canDeclareTrump && eligible) {
-                            onClick = () => handleCardClick(idx);
-                        } else if (canExchangeKitty) {
-                            onClick = () => toggleKittyCard(idx);
-                        } else if (isPlayPhase && myTurn) {
-                            onClick = () => handlePlayCardClick(idx);
-                        }
+                        if (canDeclareTrump && eligible) onClick = () => handleCardClick(idx);
+                        else if (canExchangeKitty) onClick = () => toggleKittyCard(idx);
+                        else if (isPlayPhase && myTurn) onClick = () => handlePlayCardClick(idx);
 
                         return (
                             <div key={idx} style={{ opacity: dimmed ? 0.4 : 1 }}>

--- a/frontend_code/src/components/JoinGame.js
+++ b/frontend_code/src/components/JoinGame.js
@@ -1,24 +1,15 @@
-import React, { useState } from "react";
-
+import { useState } from "react";
 
 const JoinGame = (props) => {
-
-    const [inputUserID, setInputUserID] = useState('');
-    const [inputGameCode, setInputGameCode] = useState('');
-
-    const onChangeGameCodeInput = (event) => {
-        setInputGameCode(event.target.value);
-        return true;
-    }
-
-    const onChangeUserIdInput = (event) => {
-        setInputUserID(event.target.value);
-        return true;
-    }
+    const [nickName, setNickName] = useState('');
+    const [gameCode, setGameCode] = useState('');
+    const [error, setError] = useState('');
 
     const joinGame = (game_code, nick_name) => {
-        fetch('/join/' +game_code + '?nick_name='+nick_name).then((res) => 
-            res.json().then((data)=> {
+        setError('');
+        fetch('/join/' + game_code + '?nick_name=' + nick_name).then((res) => {
+            if (!res.ok) throw new Error('Failed to join game. Check the game code.');
+            res.json().then((data) => {
                 props.updateSessionInfo('game_code', game_code);
                 props.updateSessionInfo('user_name', nick_name);
                 props.updateSessionInfo('user_uuid', data.new_player_uuid);
@@ -26,30 +17,45 @@ const JoinGame = (props) => {
                 props.updateSessionInfo('host', false);
                 props.updateLobby(true);
             })
-        );
+        }).catch(err => setError(err.message || 'Failed to join game'));
     }
 
-
-    const formSubmitHandler = (event) => {
+    const onSubmit = (event) => {
         event.preventDefault();
-        joinGame(inputGameCode, inputUserID);
-        return true;
+        if (!gameCode.trim() || !nickName.trim()) {
+            setError('Please enter both a game code and nickname');
+            return;
+        }
+        joinGame(gameCode, nickName);
     }
 
     return (
-        <div>
-            <form onSubmit={formSubmitHandler}>
-            <p>Join Existing Game</p>
-            <label htmlFor="gamecode">Game Code:</label>
-            <input type="text" id="gamecode" name="gamecode" value={inputGameCode} onChange={(e) => onChangeGameCodeInput(e)} />
-            <br/>
-            <label htmlFor="nick_name">NickName:</label>
-            <input type="text" id="nick_name" name="nick_name" value={inputUserID} onChange={(e) => onChangeUserIdInput(e)} />
-            <br/>
-            <input type="submit" value="Submit" />
+        <div className="form-card">
+            <h3>Join Existing Game</h3>
+            <form onSubmit={onSubmit}>
+                <label htmlFor="join_gamecode">Game Code</label>
+                <input
+                    type="text"
+                    id="join_gamecode"
+                    name="gamecode"
+                    value={gameCode}
+                    onChange={(e) => setGameCode(e.target.value)}
+                    placeholder="e.g. apple-banana-cherry"
+                />
+                <label htmlFor="join_nick">Nickname</label>
+                <input
+                    type="text"
+                    id="join_nick"
+                    name="nick_name"
+                    value={nickName}
+                    onChange={(e) => setNickName(e.target.value)}
+                    placeholder="Enter your name"
+                />
+                <button type="submit" className="btn btn-primary">Join Game</button>
             </form>
+            {error && <p className="error-text">{error}</p>}
         </div>
-    )
+    );
 }
 
 export default JoinGame;

--- a/frontend_code/src/components/Lobby.js
+++ b/frontend_code/src/components/Lobby.js
@@ -5,6 +5,7 @@ const Lobby = (props) => {
     const [gameState, setGameState] = useState({});
     const [errorMessage, setErrorMessage] = useState('');
     const socketRef = useRef(null);
+    const handedOffToGame = useRef(false);
 
     const game_code = props.sessionInfo['game_code'];
     const player_uuid = props.sessionInfo['user_uuid'];
@@ -27,6 +28,7 @@ const Lobby = (props) => {
             setGameState(data);
             if (data.game_event_state && data.game_event_state !== 'waiting-for-player-to-join') {
                 if (props.onGameStarted) {
+                    handedOffToGame.current = true;
                     props.onGameStarted(data, socket);
                 }
             }
@@ -42,7 +44,10 @@ const Lobby = (props) => {
         });
 
         return function cleanup() {
-            socket.disconnect();
+            // Don't disconnect if the socket was handed off to Game component
+            if (!handedOffToGame.current) {
+                socket.disconnect();
+            }
         };
     }, [game_code, player_uuid]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/frontend_code/src/components/Lobby.js
+++ b/frontend_code/src/components/Lobby.js
@@ -1,9 +1,9 @@
-import React, { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef } from "react";
 import { io } from "socket.io-client";
 
 const Lobby = (props) => {
-
     const [gameState, setGameState] = useState({});
+    const [errorMessage, setErrorMessage] = useState('');
     const socketRef = useRef(null);
 
     const game_code = props.sessionInfo['game_code'];
@@ -13,10 +13,6 @@ const Lobby = (props) => {
     useEffect(() => {
         const socket = io("http://127.0.0.1:5050", {
             transports: ["websocket"],
-            cors: {
-                origin: "http://localhost:3000",
-                methods: ["GET", "POST"]
-            },
         });
 
         socketRef.current = socket;
@@ -29,8 +25,6 @@ const Lobby = (props) => {
         socket.on('game_stats', (data) => {
             console.log('received game_stats', data);
             setGameState(data);
-
-            // Transition to game if state has moved past lobby
             if (data.game_event_state && data.game_event_state !== 'waiting-for-player-to-join') {
                 if (props.onGameStarted) {
                     props.onGameStarted(data, socket);
@@ -44,15 +38,14 @@ const Lobby = (props) => {
 
         socket.on("error", (data) => {
             console.error("Socket error:", data);
+            setErrorMessage(data.message || 'An error occurred');
         });
 
         return function cleanup() {
             socket.disconnect();
         };
+    }, [game_code, player_uuid]); // eslint-disable-line react-hooks/exhaustive-deps
 
-    }, [game_code, player_uuid]);
-
-    // Also fetch initial state via REST
     useEffect(() => {
         fetch('/game/' + game_code + '/player/' + player_uuid)
             .then(res => res.json())
@@ -73,36 +66,50 @@ const Lobby = (props) => {
     const canStart = isHost && gameState.can_start_game;
 
     return (
-        <div style={{ padding: '20px' }}>
-            <h2>Game Lobby</h2>
-            <p><strong>Game Code:</strong> {game_code}</p>
-            <p><strong>Your Name:</strong> {gameState.name}</p>
-            <p><strong>Role:</strong> {isHost ? "Host" : "Player"}</p>
+        <div className="lobby-container">
+            <div className="lobby-card">
+                {errorMessage && (
+                    <div className="info-panel error" style={{ marginBottom: '16px' }}>
+                        <span>{errorMessage}</span>
+                        <button className="close-btn" onClick={() => setErrorMessage('')}>✕</button>
+                    </div>
+                )}
 
-            <h3>Players ({playerList.length})</h3>
-            <ul>
-                {playerList.map((player, idx) => (
-                    <li key={player.uuid || idx}>
-                        {player.name}
-                        {gameState.hosting && player.uuid === player_uuid && " (you, host)"}
-                        {!gameState.hosting && player.uuid === player_uuid && " (you)"}
-                    </li>
-                ))}
-            </ul>
+                <h2>Game Lobby</h2>
+                <div className="game-code-display">{game_code}</div>
+                <p style={{ fontSize: '0.9rem', color: '#7f8c8d' }}>
+                    Share this code with friends to join
+                </p>
 
-            {isHost && !canStart && (
-                <p><em>Waiting for more players (need at least 5)...</em></p>
-            )}
+                <p style={{ fontSize: '0.95rem' }}>
+                    Playing as <strong>{gameState.name}</strong>
+                    {isHost && <span style={{ color: '#e67e22' }}> (Host)</span>}
+                </p>
 
-            {canStart && (
-                <button onClick={handleStartGame} style={{ padding: '10px 20px', fontSize: '16px', cursor: 'pointer' }}>
-                    Start Game
-                </button>
-            )}
+                <h3 style={{ marginBottom: '8px' }}>Players ({playerList.length})</h3>
+                <ul className="player-list">
+                    {playerList.map((player, idx) => (
+                        <li key={player.uuid || idx} className={player.uuid === player_uuid ? 'is-you' : ''}>
+                            {player.name}
+                            {player.uuid === player_uuid && ' (you)'}
+                        </li>
+                    ))}
+                </ul>
 
-            {!isHost && (
-                <p><em>Waiting for host to start the game...</em></p>
-            )}
+                {isHost && !canStart && (
+                    <p className="lobby-status">Waiting for more players (need at least 5)...</p>
+                )}
+
+                {canStart && (
+                    <button onClick={handleStartGame} className="btn btn-primary">
+                        Start Game
+                    </button>
+                )}
+
+                {!isHost && (
+                    <p className="lobby-status">Waiting for host to start the game...</p>
+                )}
+            </div>
         </div>
     );
 }

--- a/frontend_code/src/components/Lobby.js
+++ b/frontend_code/src/components/Lobby.js
@@ -80,7 +80,12 @@ const Lobby = (props) => {
                     </div>
                 )}
 
-                <h2>Game Lobby</h2>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                    <h2 style={{ margin: 0 }}>Game Lobby</h2>
+                    {props.onLeaveGame && (
+                        <button className="btn-leave" onClick={props.onLeaveGame}>Leave</button>
+                    )}
+                </div>
                 <div className="game-code-display">{game_code}</div>
                 <p style={{ fontSize: '0.9rem', color: '#7f8c8d' }}>
                     Share this code with friends to join

--- a/frontend_code/src/index.css
+++ b/frontend_code/src/index.css
@@ -1,10 +1,12 @@
 body {
   margin: 0;
+  padding: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background: #1a472a;
 }
 
 code {


### PR DESCRIPTION
Session validation: Added validate_player() to all 6 WebSocket handlers to verify players belong to the game before processing actions
Reconnection support: Session persisted to localStorage; auto-rejoins on page refresh; Game.js creates its own WebSocket if needed
Card sorting: Hands sorted by suit then rank, with trump cards grouped together
Error handling: All components now display server errors via dismissible banners and input validation
CSS overhaul: Green felt card-table theme with responsive design for mobile (640px/400px breakpoints)
Dead code cleanup: Removed unused DB functions and imports
Bug fixes:
Lobby was disconnecting the shared WebSocket on unmount, killing all player connections when the game started
Backend parsed enum names ("SPADE") as integer values — added parse_suit/parse_rank helpers
set_player_as_leading_player wasn't setting current_player.player_uuid, so nobody could take their turn after kitty exchange
validate_multi_card_play rejected all leading plays because it compared card count against the empty leading hand
Leave Game button: Added to both Lobby and Game header